### PR TITLE
Modify celebrate.gun permission

### DIFF
--- a/src/main/java/org/creativecraft/celebrate/Listeners/FireworkGunListener.java
+++ b/src/main/java/org/creativecraft/celebrate/Listeners/FireworkGunListener.java
@@ -40,7 +40,7 @@ public class FireworkGunListener implements Listener {
             !e.getAction().equals(Action.RIGHT_CLICK_AIR) ||
             e.getItem() == null ||
             !e.getItem().getType().equals(Material.valueOf(plugin.getConfig().getString("gun.type", "IRON_HORSE_ARMOR"))) ||
-            !e.getPlayer().hasPermission("celebrate.gun")
+            !e.getPlayer().hasPermission("celebrate.gun.use")
         ) {
             return;
         }


### PR DESCRIPTION
Modify celebrate.gun permission to separate between being able to give yourself a gun item and the player being able to use the gun via the onPlayerInteract event

Solving: https://github.com/CreativeCraft/celebrate/issues/18