### PR TITLE
Modify celebrate.gun permission

### DIFF
--- a/src/main/java/org/creativecraft/celebrate/Commands/CelebrateCommand.java
+++ b/src/main/java/org/creativecraft/celebrate/Commands/CelebrateCommand.java
@@ -143,7 +143,7 @@ public class CelebrateCommand extends BaseCommand {
      * @param player The command sender.
      */
     @Subcommand("gun")
-    @CommandPermission("celebrate.gun")
+    @CommandPermission("celebrate.gun.give")
     @Description("Retrieve a firework gun into your inventory.")
     public void onGunCommand(Player player) {
         String name = ChatColor.translateAlternateColorCodes(


### PR DESCRIPTION
Modify celebrate.gun permission to separate between being able to give yourself a gun item and the player being able to use the gun via the onPlayerInteract event

Solving: https://github.com/CreativeCraft/celebrate/issues/18